### PR TITLE
fix xcode's warning for the code document

### DIFF
--- a/MGJRouter/MGJRouter.h
+++ b/MGJRouter/MGJRouter.h
@@ -46,7 +46,7 @@ typedef id (^MGJRouterObjectHandler)(NSDictionary *routerParameters);
 /**
  *  取消注册某个 URL Pattern
  *
- *  @param URLPattern
+ *  @param URLPattern URLPattern
  */
 + (void)deregisterURLPattern:(NSString *)URLPattern;
 
@@ -70,7 +70,7 @@ typedef id (^MGJRouterObjectHandler)(NSDictionary *routerParameters);
  *  打开此 URL，带上附加信息，同时当操作完成时，执行额外的代码
  *
  *  @param URL        带 Scheme 的 URL，如 mgj://beauty/4
- *  @param parameters 附加参数
+ *  @param userInfo 附加参数
  *  @param completion URL 处理完成后的 callback，完成的判定跟具体的业务相关
  */
 + (void)openURL:(NSString *)URL withUserInfo:(NSDictionary *)userInfo completion:(void (^)(id result))completion;
@@ -78,24 +78,24 @@ typedef id (^MGJRouterObjectHandler)(NSDictionary *routerParameters);
 /**
  * 查找谁对某个 URL 感兴趣，如果有的话，返回一个 object
  *
- *  @param URL
+ *  @param URL 带 Scheme，如 mgj://beauty/3
  */
 + (id)objectForURL:(NSString *)URL;
 
 /**
  * 查找谁对某个 URL 感兴趣，如果有的话，返回一个 object
  *
- *  @param URL
- *  @param userInfo
+ *  @param URL 带 Scheme，如 mgj://beauty/3
+ *  @param userInfo 附加参数
  */
 + (id)objectForURL:(NSString *)URL withUserInfo:(NSDictionary *)userInfo;
 
 /**
  *  是否可以打开URL
  *
- *  @param URL
+ *  @param URL 带 Scheme，如 mgj://beauty/3
  *
- *  @return
+ *  @return 返回BOOL值
  */
 + (BOOL)canOpenURL:(NSString *)URL;
 
@@ -109,7 +109,7 @@ typedef id (^MGJRouterObjectHandler)(NSDictionary *routerParameters);
  *  @param pattern    url pattern 比如 @"beauty/:id"
  *  @param parameters 一个数组，数量要跟 pattern 里的变量一致
  *
- *  @return
+ *  @return 返回生成的URL String
  */
 + (NSString *)generateURLWithPattern:(NSString *)pattern parameters:(NSArray *)parameters;
 @end

--- a/MGJRouterDemo/MGJRouterDemo.xcodeproj/project.pbxproj
+++ b/MGJRouterDemo/MGJRouterDemo.xcodeproj/project.pbxproj
@@ -179,7 +179,7 @@
 		6AA6275E1B1574CA003A6B2B /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = juangua;
 				TargetAttributes = {
 					6AA627651B1574CA003A6B2B = {
@@ -285,14 +285,17 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -328,8 +331,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -358,6 +363,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = MGJRouterDemo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mogujie.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -368,6 +374,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = MGJRouterDemo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mogujie.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -386,6 +393,7 @@
 				);
 				INFOPLIST_FILE = MGJRouterDemoTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mogujie.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MGJRouterDemo.app/MGJRouterDemo";
 			};
@@ -401,6 +409,7 @@
 				);
 				INFOPLIST_FILE = MGJRouterDemoTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mogujie.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MGJRouterDemo.app/MGJRouterDemo";
 			};
@@ -425,6 +434,7 @@
 				6AA6278B1B1574CA003A6B2B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		6AA6278C1B1574CA003A6B2B /* Build configuration list for PBXNativeTarget "MGJRouterDemoTests" */ = {
 			isa = XCConfigurationList;
@@ -433,6 +443,7 @@
 				6AA6278E1B1574CA003A6B2B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/MGJRouterDemo/MGJRouterDemo/Info.plist
+++ b/MGJRouterDemo/MGJRouterDemo/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.mogujie.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/MGJRouterDemo/MGJRouterDemoTests/Info.plist
+++ b/MGJRouterDemo/MGJRouterDemoTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.mogujie.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
before this issue be fixed,you can use the code snippet bellow to suppress this warning when you import the MGJRouter.h:
#pragma clang diagnostic push
#pragma clang diagnostic ignored "-Wdocumentation"
#import "MGJRouter.h"
#pragma clang pop