### PR TITLE
2021.02.02 更新 修复URL为nil NULL 时程序闪退

### DIFF
--- a/MGJRouter/MGJRouter.m
+++ b/MGJRouter/MGJRouter.m
@@ -59,7 +59,19 @@ NSString *const MGJRouterParameterUserInfo = @"MGJRouterParameterUserInfo";
 
 + (void)openURL:(NSString *)URL withUserInfo:(NSDictionary *)userInfo completion:(void (^)(id result))completion
 {
-    URL = [URL stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    if (URL.length == 0 || [URL isEqualToString:@""] || URL == nil || URL == NULL || [URL isEqualToString:@"<null>"] || [URL isEqualToString:@"(null)"]) {
+        NSLog(@"\n###############################################\n-------- MGJRouter openURL URL不能为空 ---------\n##############################################");
+        return;
+    }
+    if (![URL containsString:@"://"]) {
+        NSLog(@"\n###############################################\n-------- MGJRouter openURL URL格式不正确,正确格式如(mgj://foo/bar)---------\n##############################################");
+        return;
+    }
+    if (@available(iOS 9.0, *)) {
+        URL = [URL stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet  URLQueryAllowedCharacterSet]];
+    }else{
+        URL = [URL stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    }
     NSMutableDictionary *parameters = [[self sharedInstance] extractParametersFromURL:URL matchExactly:NO];
     
     [parameters enumerateKeysAndObjectsUsingBlock:^(id key, NSString *obj, BOOL *stop) {
@@ -134,7 +146,11 @@ NSString *const MGJRouterParameterUserInfo = @"MGJRouterParameterUserInfo";
 {
     MGJRouter *router = [MGJRouter sharedInstance];
     
-    URL = [URL stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    if (@available(iOS 9.0, *)) {
+        URL = [URL stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet  URLQueryAllowedCharacterSet]];
+    }else{
+        URL = [URL stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    }
     NSMutableDictionary *parameters = [router extractParametersFromURL:URL matchExactly:NO];
     MGJRouterObjectHandler handler = parameters[@"block"];
     


### PR DESCRIPTION
1: 修复openURL  URL 为 nil NULL 时  在执行 [pathComponents addObject:pathSegments[0]];  时会将 nil 添加到一个可变数组 造成程序闪退 reason: '*** -[__NSArrayM insertObject:atIndex:]: object cannot be nil
2:增加判断URL 格式是否正确,非URL时打印提示
3:完美主义防止警告   iOS 9 后 使用 stringByAddingPercentEncodingWithAllowedCharacters 进行URL编码

备注:
发现URL没有做nil NULL 值处理,如在URL 是在后台返回时,很有可能未返回,或者解析为nil 值 造成使用时APP 闪退